### PR TITLE
Link out to launch event slides

### DIFF
--- a/index.Rmd
+++ b/index.Rmd
@@ -56,8 +56,9 @@ _Andrea Ammon, ECDC Director_
 > “Exploring plausible scenarios for the future of the COVID-19 pandemic can provide valuable insights for planning purposes. This Scenario Hub will bring together the expertise of different modelling teams to help policymakers come to informed decisions.”
 _Sebastian Funk, Professor of Infectious Disease Dynamics at LSHTM_
 
-**Learn more** by viewing presentations from our launch event.
+**[Learn more](https://drive.google.com/drive/u/0/folders/13eaNhZAUElv8Bu6nMUAWPiVEqNz6YqSa?ths=true)** from presenters from our launch event
 
 <div>
   <object class="embed-pdf" data="presentations/Euro-Scenario-Hub-launch.pdf" type="application/pdf">
 </div>
+


### PR DESCRIPTION
In addition to the PDF box.

It looks like the PDF box doesn't show on mobile devices and good to have a download link anyway.