### PR TITLE
Report 2 updates

### DIFF
--- a/code/load/scenarios.R
+++ b/code/load/scenarios.R
@@ -87,13 +87,15 @@ _** If a second booster is already offered to 60+ (Greece, Netherlands), a third
   # Round 2
   "round-2" = list("round" = 2,
                    "scenario_labels" = c(
-                     "A-2022-07-24" = "60+Booster/Optimistic",
-                     "B-2022-07-24" = "18+Booster/Optimistic",
-                     "C-2022-07-24" = "60+Booster/Pessimistic",
-                     "D-2022-07-24" = "18+Booster/Pessimistic"),
+                     # Short text label for scenarios in format:
+                     #  "Policy scenario / Epidemiological scenario"
+                     "A-2022-07-24" = "60+Booster/Optimistic VE",
+                     "B-2022-07-24" = "18+Booster/Optimistic VE",
+                     "C-2022-07-24" = "60+Booster/Pessimistic VE",
+                     "D-2022-07-24" = "18+Booster/Pessimistic VE"),
                    "origin_date" = as.Date("2022-07-24"),
                    "submission_window_end" = as.Date("2022-07-29"),
-                   "scenario_caption" = "Guide to scenarios: ",
+                   "scenario_caption" = "Scenarios: Autumn second booster campaign among population aged '18+' or '60+'; vaccine effectiveness is 'optimistic'(effectiveness as of a booster vaccine against Delta) or 'pessimistic' (as against BA.4/BA.5/BA.2.75)",
                    "table" = "<table>
   <tr>
     <td></td>

--- a/report2.Rmd
+++ b/report2.Rmd
@@ -51,7 +51,7 @@ results <- arrow::read_parquet(data_path) |>
 multi_country <- distinct(results, model, location) %>%
   group_by(location) %>%
   tally() %>%
-  filter(n >= 2) %>%
+  filter(n >= 3) %>%
   pull(location)
 results_multi_country <- filter(results, location %in% multi_country)
 

--- a/report2.Rmd
+++ b/report2.Rmd
@@ -39,19 +39,24 @@ download.file(
   glue::glue("https://github.com/covid19-forecast-hub-europe/covid19-scenario-hub-europe/releases/download/round{params$round}/round{params$round}.parquet"),
   data_path
 )
+
 results <- arrow::read_parquet(data_path) |> 
   left_join(read.csv("https://raw.githubusercontent.com/covid19-forecast-hub-europe/covid19-scenario-hub-europe/round1/data-locations/locations_eu.csv")) |> 
   mutate(
     value_100k = value / population * 1e5,
-    scenario_label =  recode(scenario_id, !!!scenarios[[round_text]][["scenario_labels"]])
-  ) 
+    scenario_label = recode(scenario_id,
+                            !!!sort(scenarios[[round_text]][["scenario_labels"]]))
+  ) |> 
+  separate(scenario_label, into = c("scenario_policy", "scenario_epi"), 
+           sep = "/", remove = FALSE)
   
-
 # Filter results to countries with multiple models
+n_model_min <- 3
+
 multi_country <- distinct(results, model, location) %>%
   group_by(location) %>%
   tally() %>%
-  filter(n >= 3) %>%
+  filter(n >= n_model_min) %>%
   pull(location)
 results_multi_country <- filter(results, location %in% multi_country)
 
@@ -66,8 +71,8 @@ truth <- load_truth(
 # Formatting -----------------------------------------------------------------
 # create consistent model and scenario colour palettes
 palette <- plot_palettes(results,
-                         scenario_reds = c("A", "C"),
-                         scenario_blues = c("B", "D"))
+                         scenario_reds = c("A", "B"),
+                         scenario_blues = c("C", "D"))
 target_dirs <- gsub("inc ", "", scenarios$targets)
 names(target_dirs) <- gsub("Weekly ", "", names(target_dirs))
 names(target_dirs) <- tools::toTitleCase(names(target_dirs))
@@ -88,7 +93,7 @@ See also the [full scenario details](`r paste0("https://github.com/covid19-forec
 
 In Round `r params$round`, we asked modellers to start their projections from the `r scenarios[[round_text]][["origin_date"]]`. Data after this date were not included, and as a result, model projections are unlikely to fully account for later information on the changing variants or behavioural patterns.
 
-In this report we only show results from countries with multiple models.
+In this report we only show results from countries with at least `r n_model_min` models.
 
 ## Current situation
 
@@ -100,14 +105,9 @@ plot <- plot_vaccination_by_age(location_codes = multi_country)
 plot
 ```
 
-We note that the following countries are already implementing a second booster dose among the 60+ age group:
-
-- Netherlands
-- Greece
-
 ## Participating teams {.tabset .tabset-pills}
 
-`r n_distinct(results_multi_country$model)` models contributed scenario projections to Round `r params$round`. No country had results from more than two models. Given this low coverage, we did not produce an ensemble model. 
+`r n_distinct(results_multi_country$model)` models contributed scenario projections to Round `r params$round`. 
 
 ### Models
 
@@ -148,15 +148,10 @@ targets_summary |>
 
 # Cumulative outcomes {.tabset .tabset-pills}
 
-For each model and scenario, we compare the total number of outcomes over the entire projection period as a % of the total country population. We compared the cumulative number of projected outcomes to the cumulative total over one year before projections started (May 2021 - May 2022). 
+For each model and scenario, we compare the total number of outcomes over the entire projection period as a % of the total country population. We compared the cumulative number of projected outcomes to the cumulative total over one year before projections started (`r format(min(results_multi_country$target_end_date) - lubridate::years(1), "%B% %Y")` to `r format(min(results_multi_country$target_end_date), "%B% %Y")`).
 
 **Observations**
 
-- Across all scenarios, we observed very low or no probability of deaths over the next year matching the previous year's total. This was not true of other outcomes with comparative observed data (cases, hospitalisations).
-
-- Comparing scenarios by immune assumptions, we observed higher total counts of projected outcomes when immunity was modelled as weaker (a faster decline to a reduced plateau of immunity). In these scenarios, in many countries the number of cases projected over the next year approached or exceeded the total observed over the last year.  
-
-- However, recent data indicate the optimistic scenario of immune waning may be more likely than the pessimistic scenario. Between scenarios with strong immunity (-60% over 8 months), we observed relatively little difference in cumulative outcomes between scenarios providing a summer or an autumn booster campaign. 
 
 **Projections**
 
@@ -168,23 +163,17 @@ cumulative_plots <- plot_cumulative_summary(data = results_multi_country,
 
 scenarios$targets |> 
   purrr::map_chr(function(target) {
-    knitr::knit_expand("_cumulative_plots.Rmd", target = target)
-  }) |> 
+    knitr::knit_expand("_cumulative_plots.Rmd", target = target)}) |> 
   knitr::knit_child(text = _, quiet = TRUE) |> 
   cat(sep = "\n\n\n")
 ```
 
 # Incident outcomes {.tabset}
 
-We explored the incidence of COVID-19 per 100,000 over the projection period and in terms of projected peaks in incidence. We summarised peaks both over the entire projection period, and over only the autumn-winter period (November through March); we considered (A) the timing and maximum weekly incidence of each peak, and (B) the total number of peaks.
+We explored the incidence of COVID-19 per 100,000 over the projection period and in terms of projected peaks in incidence. We summarised peaks both over the entire projection period, and over only the autumn-winter period (October through March); we considered (A) the timing and maximum weekly incidence of each peak, and (B) the total number of peaks.
 
 **Observations**
 
-- Across scenarios for hospitalisations, we noted that peak sizes rarely approached the highest level previously observed (dotted line). 
-
-- We saw no systematic difference in the number of peaks between scenarios modelling a booster campaign in summer versus autumn, but as before, differences were more clearly between a longer or shorter duration of waning immunity. 
-
-- Comparing projections for deaths, we noticed that projected peaks shift to slightly later in the year with a vaccination campaign in the summer compared to autumn, moving the likely timing of a peak from late summer/autumn into winter.
 
 **Projections**
 
@@ -193,8 +182,7 @@ We explored the incidence of COVID-19 per 100,000 over the projection period and
 ```{r plot-projections, results = 'asis'}
 scenarios$targets |> 
   purrr::map_chr(function(target) {
-    knitr::knit_expand("_by_scenario.Rmd", target = target)
-  }) |> 
+    knitr::knit_expand("_by_scenario.Rmd", target = target)}) |> 
   knitr::knit_child(text = _, quiet = TRUE) |> 
   cat(sep = "\n\n\n")
 ```
@@ -224,13 +212,12 @@ peak_size_plot[["aw"]] <- plot_peak_size(peaks = peaks_aw, truth = truth)
 
 ### Autumn-winter {.tabset .tabset-pills}
 
-*Projections over November 2022 through March 2023*
+*Projections over October 2022 through March 2023*
 
 ```{r plot-peaks-aw, results = 'asis'}
 scenarios$targets |> 
   purrr::map_chr(function(target) {
-    knitr::knit_expand("_peaks.Rmd", target = target, period = "aw")
-  }) |> 
+    knitr::knit_expand("_peaks.Rmd", target = target, period = "aw")}) |> 
   knitr::knit_child(text = _, quiet = TRUE) |> 
   cat(sep = "\n\n\n")
 ```
@@ -243,8 +230,7 @@ scenarios$targets |>
 ```{r plot-peaks-alltime, results = 'asis'}
 scenarios$targets |> 
   purrr::map_chr(function(target) {
-    knitr::knit_expand("_peaks.Rmd", target = target, period = "full")
-  }) |> 
+    knitr::knit_expand("_peaks.Rmd", target = target, period = "full") }) |> 
   knitr::knit_child(text = _, quiet = TRUE) |> 
   cat(sep = "\n\n\n")
 ```


### PR DESCRIPTION
First update to shorten the report. I will add more updates tomorrow, but ideally we could merge this in now in order to share with ecdc. Changes are minor.


---
Changes:

Data loading/plotting:
- Facet some plots by "epidemiological" and "policy" scenarios - for easier comparisons
- Add scenario label guide

report2.Rmd:
- Separate scenario labels into "policy"/"epi"
- Only display countries with 3+ models
- Remove "observations" text (to be replaced)