### PR TITLE
Tidy up scenario reports & add round 3 scenario description

### DIFF
--- a/_site.yml
+++ b/_site.yml
@@ -9,17 +9,17 @@ navbar:
     - text: "Scenarios"
       icon: fa-virus
       href: scenarios.html
+      menu:
+        - text: "Round 1"
+          href: report1.html
+        - text: "Round 2"
+          href: report2.html
     - text: "Community"
       icon: fa-users
       href: community.html
     - text: "Models"
       icon: fa-file-spreadsheet
       href: models.html
-    - text: "Reports"
-      icon: fa-file-alt
-      menu:
-        - text: "Round 1"
-          href: report1.html
     - text: "Contact"
       icon: fa-envelope
       href: contact.html

--- a/_site.yml
+++ b/_site.yml
@@ -10,6 +10,8 @@ navbar:
       icon: fa-virus
       href: scenarios.html
       menu:
+        - text: "Overview"
+          href: scenarios.html
         - text: "Round 1"
           href: report1.html
         - text: "Round 2"

--- a/code/load/scenarios.R
+++ b/code/load/scenarios.R
@@ -192,5 +192,97 @@ _** If a second booster is already offered to 60+ (Greece, Netherlands), a third
     </td>
   </tr>
 </table>"
+  ),
+  # -------------------------------------------------------------------------
+  # Round 3
+  "round-3" = list("round" = 3,
+                   # Short text label for scenarios in format:
+                   #  "Policy scenario / Epidemiological scenario"
+                   "scenario_labels" = c(
+                     "A" = "A. No vaccination, optimistic variants",
+                     "B" = "B. Annual vaccination, optimistic variants",
+                     "C" = "C. Biannual vaccination, optimistic variants",
+                     "D" = "D. No vaccination, pessimistic variants",
+                     "E" = "E. Annual booster campaign, pessimistic variants",
+                     "F" = "F. Biannual booster campaign, pessimistic variants"
+                     ),
+                   # Key dates
+                   "origin_date" = as.Date("2022-09-11"),
+                   "submission_window_end" = as.Date("2022-09-16"),
+                   # Short scenario guide (for website + figure captions)
+                   "scenario_caption" = "Scenarios: New vaccination (none/annual/biannual); \n New variants (optimistic/pessimistic)",
+                   # HTML format scenario table
+                   "table" = "<table> <tr>
+      <td>
+        Notes
+       <li> * Vaccination as planned = Primary schedule + 2 booster doses </li>
+       <li> ** Seasonal vaccination campaigns: Autumn = 15 September to 15 December; Spring = 15 March to 15 June
+      </td>
+      <td>
+        <b> No further vaccination </b><br>
+        <ul>
+            <li> Vaccination as planned*
+            <li> <b>No</b> further vaccination </li>
+        </ul>
+      </td>
+      <td>
+        <b> Annual vaccination </b><br>
+        <ul>
+            <li> Vaccination as planned* </li>
+            <li> <b>2023 onwards</b>: annual vaccination programme in <b>autumn</b>** </li>
+            <li> Uptake higher in 60+ than <60 age groups</li>
+        </ul>
+      </td>
+      <td>
+        <b> Bi-annual vaccination </b><br>
+        <ul>
+            <li> Vaccination as planned </li>
+            <li> <b>2023 onwards</b>: bi-annual (2 per year) vaccination in <b>spring</b>** and <b>autumn</b>**</li>
+            <li> Uptake higher in 60+ than <60 age groups </li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <b>Optimistic variant scenario</b><br>
+        <ul>
+          <li><b>20%</b> reduction in immunity against <b>infection</b> </li>
+          <li><b>0%</b> reduction in immunity against <b>severe</b> outcome </li>
+          <li><b>One new variant</b> every 9 months
+          <li> First introduction: <b>1st October 2022 </b></li>
+        </ul>
+      </td>
+      <td>
+        Scenario A
+      </td>
+      <td>
+        Scenario B
+      </td>
+      <td>
+        Scenario C
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <b>Pessimistic variant scenario</b><br>
+        <ul>
+          <li><b>75%</b> reduction in immunity against <b>infection</b> </li>
+          <li><b>20%</b> reduction in immunity against <b>severe</b> outcomes </li>
+          <li><b>One new variant</b> every 9 months
+          <li> First introduction: <b>1st October 2022 </b></li>
+        </ul>
+      </td>
+      <td>
+        Scenario D
+      </td>
+      <td>
+        Scenario E
+      </td>
+      <td>
+        Scenario F
+      </td>
+    </tr>
+  </table>"
   )
 )
+

--- a/code/load/scenarios.R
+++ b/code/load/scenarios.R
@@ -76,7 +76,7 @@ scenarios <- list(
                                       "D-2022-05-22" = "Weak/Autumn"),
     "origin_date" = as.Date("2022-05-22"),
     "submission_window_end" = as.Date("2022-07-01"),
-    "scenario_caption" = "_Guide to scenarios: Stronger or weaker immunity maintained over time ('Strong/Weak'); \n 60+ second booster campaign starting in summer or autumn ('Summer/Autumn')_",
+    "scenario_caption" = "Scenarios: Stronger or weaker immunity maintained over time ('Strong/Weak'); \n 60+ second booster campaign starting in summer or autumn ('Summer/Autumn')",
     "table" = "<table>
   <tr>
     <td></td>
@@ -144,7 +144,7 @@ _** If a second booster is already offered to 60+ (Greece, Netherlands), a third
                      "D-2022-07-24" = "18+Booster/Pessimistic VE"),
                    "origin_date" = as.Date("2022-07-24"),
                    "submission_window_end" = as.Date("2022-07-29"),
-                   "scenario_caption" = "Scenarios: Autumn second booster campaign among population aged '18+' or '60+'; vaccine effectiveness is 'optimistic'(effectiveness as of a booster vaccine against Delta) or 'pessimistic' (as against BA.4/BA.5/BA.2.75)",
+                   "scenario_caption" = "Scenarios: Autumn second booster campaign among population aged '18+' or '60+'; \n Vaccine effectiveness is 'optimistic'(effectiveness as of a booster vaccine against Delta) or 'pessimistic' (as against BA.4/BA.5/BA.2.75)",
                    "table" = "<table>
   <tr>
     <td></td>

--- a/code/load/scenarios.R
+++ b/code/load/scenarios.R
@@ -16,7 +16,7 @@ scenarios <- list(
                                        "D-2022-02-25" = "Weak/New"),
                    "origin_date" = as.Date("2022-03-13"),
                    "submission_window_end" = as.Date("2022-04-22"),
-                   "scenario_caption" = "Strong/Weak = stronger/weaker immunity maintained over time; \n None/New = immune evading variant introduced May 2022",
+                   "scenario_caption" = "Scenarios: Stronger/weaker immunity maintained over time; \n None/New immune evading variant introduced May 2022",
     "table" = "<table>
   <tr>
     <td></td>

--- a/code/load/scenarios.R
+++ b/code/load/scenarios.R
@@ -212,32 +212,30 @@ _** If a second booster is already offered to 60+ (Greece, Netherlands), a third
                    # Short scenario guide (for website + figure captions)
                    "scenario_caption" = "Scenarios: New vaccination (none/annual/biannual); \n New variants (optimistic/pessimistic)",
                    # HTML format scenario table
-                   "table" = "<table> <tr>
+                   "table" = "<table>
+                   <tr>
       <td>
-        Notes
-       <li> * Vaccination as planned = Primary schedule + 2 booster doses </li>
-       <li> ** Seasonal vaccination campaigns: Autumn = 15 September to 15 December; Spring = 15 March to 15 June
       </td>
       <td>
         <b> No further vaccination </b><br>
         <ul>
-            <li> Vaccination as planned*
+            <li> Vaccination as planned<sup>*</sup> </li>
             <li> <b>No</b> further vaccination </li>
         </ul>
       </td>
       <td>
         <b> Annual vaccination </b><br>
         <ul>
-            <li> Vaccination as planned* </li>
-            <li> <b>2023 onwards</b>: annual vaccination programme in <b>autumn</b>** </li>
+            <li> Vaccination as planned<sup>*</sup> </li>
+            <li> <b>2023 onwards</b>: annual vaccination programme in <b>autumn</b><sup>**</sup> </li>
             <li> Uptake higher in 60+ than <60 age groups</li>
         </ul>
       </td>
       <td>
         <b> Bi-annual vaccination </b><br>
         <ul>
-            <li> Vaccination as planned </li>
-            <li> <b>2023 onwards</b>: bi-annual (2 per year) vaccination in <b>spring</b>** and <b>autumn</b>**</li>
+            <li> Vaccination as planned<sup>*</sup> </li>
+            <li> <b>2023 onwards</b>: bi-annual (2 per year) vaccination in <b>spring and autumn</b><sup>**</sup></li>
             <li> Uptake higher in 60+ than <60 age groups </li>
         </ul>
       </td>
@@ -248,7 +246,7 @@ _** If a second booster is already offered to 60+ (Greece, Netherlands), a third
         <ul>
           <li><b>20%</b> reduction in immunity against <b>infection</b> </li>
           <li><b>0%</b> reduction in immunity against <b>severe</b> outcome </li>
-          <li><b>One new variant</b> every 9 months
+          <li><b>One new variant</b> every 9 months </li>
           <li> First introduction: <b>1st October 2022 </b></li>
         </ul>
       </td>
@@ -268,7 +266,7 @@ _** If a second booster is already offered to 60+ (Greece, Netherlands), a third
         <ul>
           <li><b>75%</b> reduction in immunity against <b>infection</b> </li>
           <li><b>20%</b> reduction in immunity against <b>severe</b> outcomes </li>
-          <li><b>One new variant</b> every 9 months
+          <li><b>One new variant</b> every 9 months </li>
           <li> First introduction: <b>1st October 2022 </b></li>
         </ul>
       </td>
@@ -282,7 +280,11 @@ _** If a second booster is already offered to 60+ (Greece, Netherlands), a third
         Scenario F
       </td>
     </tr>
-  </table>"
+  </table>
+
+  _* Vaccination as planned = Primary schedule + 2 booster doses_
+  \n
+  _** Seasonal vaccination campaigns: Autumn = 15 September to 15 December; Spring = 15 March to 15 June_"
   )
 )
 

--- a/code/load/scenarios.R
+++ b/code/load/scenarios.R
@@ -16,7 +16,56 @@ scenarios <- list(
                                        "D-2022-02-25" = "Weak/New"),
                    "origin_date" = as.Date("2022-03-13"),
                    "submission_window_end" = as.Date("2022-04-22"),
-                   "scenario_caption" = "Strong/Weak = stronger/weaker immunity maintained over time; \n None/New = immune evading variant introduced May 2022"),
+                   "scenario_caption" = "Strong/Weak = stronger/weaker immunity maintained over time; \n None/New = immune evading variant introduced May 2022",
+    "table" = "<table>
+  <tr>
+    <td></td>
+    <td>
+      <b>No new variant
+      </b><br>
+      <ul>
+          <li>Projections are initialized with the mix of strains circulating at the start of the projection period</li>
+      </ul>
+    </td>
+    <td>
+      <b>New variant X</b><br>
+      <ul>
+          <li>Introduction: From May 1st 2022 is a continuous influx of 50 weekly infections of variant X over 16 weeks</li>
+          <li>Characteristics: Variant X has 30% immune escape, and the same intrinsic transmissibility and severity as Omicron.</li>
+      </ul>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <b> Optimistic waning of protection</b><br>
+      <ul>
+        <li>Speed: 10 months median time to transition to partial immunity</li>
+        <li>Plateau: 40% reduction in protection from baseline (protection immediately after exposure) at plateau</b></li>
+      </ul>
+    </td>
+    <td>
+      Scenario A
+    </td>
+    <td>
+      Scenario B
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <b>Pessimistic waning of protection</b><br>
+      <ul>
+        <li>Speed: 4 months median time to transition to partial immunity</li>
+        <li>Plateau: 60% reduction in protection from baseline level at immune plateau</li>
+      </ul>
+    </td>
+    <td>
+      Scenario C
+    </td>
+    <td>
+      Scenario D
+    </td>
+  </tr>
+</table>"),
   # -------------------------------------------------------------------------
   # Round 1
   "round-1" = list("round" = 1,

--- a/scenarios.Rmd
+++ b/scenarios.Rmd
@@ -5,69 +5,43 @@ output:
     toc: true
 ---
 
+```{r prep, include = FALSE}
+knitr::opts_chunk$set(echo = FALSE, 
+                      message = FALSE, warning = FALSE)
+source("code/load/scenarios.R")
+```
+
 Information about past and present rounds of scenarios is below. For modellers participating in each round,  please refer to the [Wiki](https://github.com/covid19-forecast-hub-europe/covid19-scenario-hub-europe/wiki/Scenario-rounds) for the most up to date details. For more general information on our approach to setting scenarios, read more in the [About](about.html) section.
 
 # {.tabset}
+
+## Round 2 {.tabset .tabset-pills}
+
+### Scenarios
+
+Round 2 projections begin from `r scenarios[["round-2"]][["origin_date"]]`. 
+
+```{r scenario-round-2, results = 'asis'}
+cat(paste0("_", scenarios[["round-2"]][["scenario_caption"]], "_"))
+cat("\n\n")
+cat(scenarios[["round-2"]][["table"]])
+```
+
+### Findings
+
+See the [full report](https://covid19scenariohub.eu/report2.html) for our findings from Round 2.
 
 ## Round 1 {.tabset .tabset-pills}
 
 ### Scenarios
 
-<table>
-  <tr>
-    <td></td>
-    <td>
-      <b>Slow summer booster campaign</b><br>
-      <ul>
-          <li>2nd booster recommended for 60+</li>
-          <li>Uptake reaches 50% of 1st booster coverage by 15th December</li>
-          <li>Uptake starts <b>15th June*</b></li>
-      </ul>
-    </td>
-    <td>
-      <b>Fast autumn booster campaign</b><br>
-      <ul>
-          <li>2nd** booster recommended for 60+</li>
-          <li>Uptake reaches 50% of 1st booster coverage by 15th December</li>
-          <li>Uptake starts <b>15th September</b></li>
-      </ul>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <b>Optimistic slow immune waning</b><br>
-      <ul>
-        <li>60% reduction in immunity against infection</li>
-        <li>In <b>8 months</b></li>
-      </ul>
-    </td>
-    <td>
-      Scenario A
-    </td>
-    <td>
-      Scenario B
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <b>Pessimistic fast immune waning</b><br>
-      <ul>
-        <li>60% reduction in immunity against infection</li>
-        <li>In <b>3 months</b></li>
-      </ul>
-    </td>
-    <td>
-      Scenario C
-    </td>
-    <td>
-      Scenario D
-    </td>
-  </tr>
-</table>
+Round 1 projections begin from `r scenarios[["round-1"]][["origin_date"]]`. 
 
-_* If a second booster is already offered to 60+, vaccination uptake continues as currently_
-
-_** If a second booster is already offered to 60+, a third booster dose is recommended_
+```{r scenario-round-1, results = 'asis'}
+cat(paste0("_", scenarios[["round-1"]][["scenario_caption"]], "_"))
+cat("\n\n")
+cat(scenarios[["round-1"]][["table"]])
+```
 
 ### Assumptions {.tabset}
 
@@ -166,6 +140,10 @@ We also ask modellers to assume the following:
 
 -   No novel vaccine types or novel drugs that strongly impact burden
 
+### Findings
+
+See the [full report](https://covid19scenariohub.eu/report1.html) for our findings from Round 1.
+
 ## Round 0 {.tabset .tabset-pills}
 
 We ran a pilot Round 0 over March-May 202, where we considered the differential impact of waning protection against infection against the introduction of a new variant with immune escape.
@@ -179,56 +157,13 @@ countries](https://github.com/covid19-forecast-hub-europe/covid19-scenario-hub-e
 -   [Round 0 overview](https://docs.google.com/presentation/d/1MiQsN0p-nvDF8km-OLjHOaEAqxMDwmxlOuDPu3POxnk/edit?usp=sharing)
 -   [Full scenario details - US  Hub](https://github.com/midas-network/covid19-scenario-modeling-hub#round-13-scenarios)
 
+Round 0 projections begin from `r scenarios[["round-0"]][["origin_date"]]`. 
 
-<table>
-  <tr>
-    <td></td>
-    <td>
-      <b>No new variant
-      </b><br>
-      <ul>
-          <li>Projections are initialized with the mix of strains circulating at the start of the projection period</li>
-      </ul>
-    </td>
-    <td>
-      <b>New variant X</b><br>
-      <ul>
-          <li>Introduction: From May 1st 2022 is a continuous influx of 50 weekly infections of variant X over 16 weeks</li>
-          <li>Characteristics: Variant X has 30% immune escape, and the same intrinsic transmissibility and severity as Omicron.</li>
-      </ul>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <b> Optimistic waning of protection</b><br>
-      <ul>
-        <li>Speed: 10 months median time to transition to partial immunity</li>
-        <li>Plateau: 40% reduction in protection from baseline (protection immediately after exposure) at plateau</b></li>
-      </ul>
-    </td>
-    <td>
-      Scenario A
-    </td>
-    <td>
-      Scenario B
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <b>Pessimistic waning of protection</b><br>
-      <ul>
-        <li>Speed: 4 months median time to transition to partial immunity</li>
-        <li>Plateau: 60% reduction in protection from baseline level at immune plateau</li>
-      </ul>
-    </td>
-    <td>
-      Scenario C
-    </td>
-    <td>
-      Scenario D
-    </td>
-  </tr>
-</table>
+```{r scenario-round-0, results = 'asis'}
+cat(paste0("_", scenarios[["round-0"]][["scenario_caption"]], "_"))
+cat("\n\n")
+cat(scenarios[["round-0"]][["table"]])
+```
 
 ### Projections
 
@@ -240,7 +175,7 @@ In Round 0:
 
 - 5 countries had >2 model projections
 
-### Conclusions
+### Findings
 
 As it was a pilot round, we provide only general, broad conclusions for Round 0.
 

--- a/scenarios.Rmd
+++ b/scenarios.Rmd
@@ -5,20 +5,13 @@ output:
     toc: true
 ---
 
-Information about past and present rounds of scenarios is below. For modellers participating in each round, we have reproduced key information below but please refer to the [Wiki](https://github.com/covid19-forecast-hub-europe/covid19-scenario-hub-europe/wiki/Scenario-rounds) for the most up to date details. For more general information on our approach to setting scenarios, read more in the [About](about.html) section.
+Information about past and present rounds of scenarios is below. For modellers participating in each round,  please refer to the [Wiki](https://github.com/covid19-forecast-hub-europe/covid19-scenario-hub-europe/wiki/Scenario-rounds) for the most up to date details. For more general information on our approach to setting scenarios, read more in the [About](about.html) section.
 
 # {.tabset}
 
 ## Round 1 {.tabset .tabset-pills}
 
-In this round we are exploring the impact of different timings of a [second booster campaign](#booster-campaign) while considering uncertainty around the speed of [waning immunity](#waning-immunity). We ask for projections over a period of [at least nine and at most twelve months](#key-dates).
-
--   Please aim to submit by **3 June 2022**
-    -   [Submission information, key dates, and model abstract](#submission-information) below
-    -   Please note some [important differences from Round 0](#submission-differences-from-round-0)
-    -   [Let us know](mail@covid19scenariohub.eu) if you need more time
-
-### Round 1 scenarios
+### Scenarios
 
 <table>
   <tr>
@@ -172,67 +165,6 @@ We also ask modellers to assume the following:
 -   No new variant of concern
 
 -   No novel vaccine types or novel drugs that strongly impact burden
-
-### Submission information
-
-#### Submission differences from Round 0
-
-We have updated the submission format for Round 1 and future rounds.
-
--   Sample based submissions
-
-    -   We no longer ask for results across a quantile distribution
-
-    -   Please submit **100 samples**. If you think more are needed to capture the uncertainty from the outputs, please get in touch. If you cannot provide 100 samples, please submit as many as you can.
-
-    -   Each sample should be a single simulation from your model, all with equal probability
-
-    -   See more on [submission formatting](https://github.com/covid19-forecast-hub-europe/covid19-scenario-hub-europe/wiki/Submission-format#required-variables)
-
--   Targets
-
-    -   Teams can submit one or more of any of the below targets. See more on [targets](https://github.com/covid19-forecast-hub-europe/covid19-scenario-hub-europe/wiki/Targets-and-horizons#targets)
-
-    -   Key targets:
-
-        -   Incident deaths
-
-        -   Incident cases
-
-        -   Incident hospital admissions
-
-    -   Additional targets, if teams already produce these (please get in touch if yes as we will need to create associated variable names):
-
-        -   Incident infections
-
-        -   Intensive care (ICU) admissions
-
-#### Key dates
-
-The dates for round 1 are:
-
-|                                                              | Round 1 date                         | [Epiweek](https://ibis.health.state.nm.us/resource/MMWRWeekCalendar.html#part2) ([conversion](https://www.dralshehri.com/epiweeks/)) |
-|--------------------------------------------------------------|--------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------|
-| Submissions due                                              | June 03 2022                         |                                                                                                                                      |
-| End date for fitting data                                    | May 21 2022                          | EW-20 of 2022                                                                                                                        |
-| `origin_date` (first possible date of a daily simulation)    | May 22 2022                          | First day of EW-21 of 2022                                                                                                           |
-| Earliest `target_end_date` (first week of simulated results) | May 28 2022                          | EW-21 of 2022                                                                                                                        |
-| Latest `target_end_date` (projections over 9 to 12 months)   | From February 18 2023 to May 20 2023 | From EW-07 of 2023 to EW-20 of 2023                                                                                                  |
-
-#### Scenario IDs
-
-Please use the following codes to identify between scenarios, with one for each value (row) in your [submission csv](https://github.com/covid19-forecast-hub-europe/covid19-scenario-hub-europe/wiki/Submission-format#scenario_id).
-
-| Scenario                                         | Scenario ID   |
-|--------------------------------------------------|---------------|
-| Scenario A. Slow waning, summer booster campaign | A-2022-05-22  |
-| Scenario B. Slow waning, autumn booster campaign | B-2022-05-22  |
-| Scenario C. Fast waning, summer booster campaign | C-2022-05-22  |
-| Scenario D. Fast waning, autumn booster campaign | D-2022-05-22  |
-
-#### Model abstract
-
-Please include a brief abstract for your model as part of your submission. Please make a copy of the [Round 1 Abstract template](https://github.com/covid19-forecast-hub-europe/covid19-scenario-hub-europe/blob/main/template/2022-05-22-MyTeam-MyModel-Abstract.md) and save this to your team's folder in `data-processed`, adjusting the filename format (`2022-05-22-MyTeam-MyModel-Abstract.md`).
 
 ## Round 0 {.tabset .tabset-pills}
 

--- a/scenarios.Rmd
+++ b/scenarios.Rmd
@@ -2,10 +2,10 @@
 title: "Scenarios"
 output:
   html_document:
-    toc: true
+    toc: false
 ---
 
-```{r prep, include = FALSE}
+```{r setup, include = FALSE}
 knitr::opts_chunk$set(echo = FALSE, 
                       message = FALSE, warning = FALSE)
 source("code/load/scenarios.R")
@@ -14,6 +14,26 @@ source("code/load/scenarios.R")
 Information about past and present rounds of scenarios is below. For modellers participating in each round,  please refer to the [Wiki](https://github.com/covid19-forecast-hub-europe/covid19-scenario-hub-europe/wiki/Scenario-rounds) for the most up to date details. For more general information on our approach to setting scenarios, read more in the [About](about.html) section.
 
 # {.tabset}
+
+## Round 3 {.tabset .tabset-pills}
+
+### Scenarios
+
+Round 3 projections begin from `r scenarios[["round-3"]][["origin_date"]]`. 
+
+```{r scenario-round-3, results = 'asis'}
+cat(paste0("_", scenarios[["round-3"]][["scenario_caption"]], "_"))
+cat("\n\n")
+cat(scenarios[["round-3"]][["table"]])
+```
+
+### Assumptions
+
+See our [Github Wiki](https://github.com/covid19-forecast-hub-europe/covid19-scenario-hub-europe/wiki/Round-3) for detailed guidance on the assumptions that modellers used in creating scenario projections.
+
+### Findings
+
+Round 3 submissions are anticipated by `r scenarios[["round-3"]][["submission_window_end"]]`. 
 
 ## Round 2 {.tabset .tabset-pills}
 
@@ -29,7 +49,7 @@ cat(scenarios[["round-2"]][["table"]])
 
 ### Assumptions
 
-See our [Github Wiki](https://github.com/covid19-forecast-hub-europe/covid19-scenario-hub-europe/wiki/Round-2) for detailed guidance on the assumptions that modellers use in creating scenario projections.
+See our [Github Wiki](https://github.com/covid19-forecast-hub-europe/covid19-scenario-hub-europe/wiki/Round-2) for detailed guidance on the assumptions that modellers used in creating scenario projections.
 
 ### Findings
 
@@ -150,11 +170,9 @@ See the [full report](https://covid19scenariohub.eu/report1.html) for our findin
 
 ## Round 0 {.tabset .tabset-pills}
 
-We ran a pilot Round 0 over March-May 202, where we considered the differential impact of waning protection against infection against the introduction of a new variant with immune escape.
-
 ### Scenarios
 
-Round 0 projections begin from `r scenarios[["round-0"]][["origin_date"]]`. 
+We ran a pilot round ("Round 0") over March-May 2022. Round 0 projections begin from `r scenarios[["round-0"]][["origin_date"]]`. 
 
 ```{r scenario-round-0, results = 'asis'}
 cat(paste0("_", scenarios[["round-0"]][["scenario_caption"]], "_"))

--- a/scenarios.Rmd
+++ b/scenarios.Rmd
@@ -27,6 +27,10 @@ cat("\n\n")
 cat(scenarios[["round-2"]][["table"]])
 ```
 
+### Assumptions
+
+See our [Github Wiki](https://github.com/covid19-forecast-hub-europe/covid19-scenario-hub-europe/wiki/Round-2) for detailed guidance on the assumptions that modellers use in creating scenario projections.
+
 ### Findings
 
 See the [full report](https://covid19scenariohub.eu/report2.html) for our findings from Round 2.
@@ -150,13 +154,6 @@ We ran a pilot Round 0 over March-May 202, where we considered the differential 
 
 ### Scenarios
 
-The details for this round identically match those of the [US Scenario
-Hub](https://covid19scenariomodelinghub.org/viz.html), applied to the [32
-countries](https://github.com/covid19-forecast-hub-europe/covid19-scenario-hub-europe/blob/main/data-locations/locations_eu.csv) of the European Hub.
-
--   [Round 0 overview](https://docs.google.com/presentation/d/1MiQsN0p-nvDF8km-OLjHOaEAqxMDwmxlOuDPu3POxnk/edit?usp=sharing)
--   [Full scenario details - US  Hub](https://github.com/midas-network/covid19-scenario-modeling-hub#round-13-scenarios)
-
 Round 0 projections begin from `r scenarios[["round-0"]][["origin_date"]]`. 
 
 ```{r scenario-round-0, results = 'asis'}
@@ -165,7 +162,16 @@ cat("\n\n")
 cat(scenarios[["round-0"]][["table"]])
 ```
 
-### Projections
+### Assumptions
+
+The details for this round identically match those of the [US Scenario
+Hub](https://covid19scenariomodelinghub.org/viz.html), applied to the [32
+countries](https://github.com/covid19-forecast-hub-europe/covid19-scenario-hub-europe/blob/main/data-locations/locations_eu.csv) of the European Hub.
+
+-   [Round 0 overview](https://docs.google.com/presentation/d/1MiQsN0p-nvDF8km-OLjHOaEAqxMDwmxlOuDPu3POxnk/edit?usp=sharing)
+-   [Full scenario details - US  Hub](https://github.com/midas-network/covid19-scenario-modeling-hub#round-13-scenarios)
+
+### Findings
 
 In Round 0:
 
@@ -174,8 +180,6 @@ In Round 0:
 - 8 teams started working on Round 0; 5 teams contributed results
 
 - 5 countries had >2 model projections
-
-### Findings
 
 As it was a pilot round, we provide only general, broad conclusions for Round 0.
 


### PR DESCRIPTION
This PR aims to tidy up the website a bit. Currently there is some duplication/confusion where we have the page [Scenarios](https://covid19scenariohub.eu/scenarios.html) describing each scenario round, and a separate menu under "Reports" for the resulting [reports](https://covid19scenariohub.eu/report1.html) on rounds 1 & 2. 

This PR
- Tidies up the Scenarios page describing each round: making the descriptions consistent between each round, and using the metadata in `scenarios.R` rather than plain text
- Uses the Scenarios page as the front page for the drop-down menu for reports under this page; adds link & drop-down menu link to Round 2 report
- Tidies up `scenarios.R` metadata: adding Round 0 table, adding Round 3 metadata (table, dates etc)
- Adds Round 3 scenarios as new tab on website (Scenarios page)

The main problem is getting the Round 3 HTML scenario table to format properly - I copied from the wiki page but it doesn't format properly when knitted here. I can't immediately find how to fix this so it would really help to get some HTML knowledge if @Bisaloo could have a look!

I have tried to make this PR easier to review with commit-by-commit descriptions, hope that helps. Attached a screenshot of how the new layout for the Scenarios page looks.

![image](https://user-images.githubusercontent.com/62290797/188491850-400bf20f-bbcb-46d5-a771-f71076dda3ed.png)

