### PR TITLE
Fix "Models # Model details" page

### DIFF
--- a/models.Rmd
+++ b/models.Rmd
@@ -20,7 +20,7 @@ library(purrr)
 library(stringr)
 ```
 
-This page presents the various features and implementations in the models submitted to the Scenario Hub in a comparative fashion. The learn more about each model individually, please refer to [each model abstract](#Abstracts).
+This page presents the various features and implementations in the models submitted to the Scenario Hub. To learn more about each model individually, please refer to the latest set of [models abstracts](https://github.com/covid19-forecast-hub-europe/covid19-scenario-hub-europe/tree/main/model-abstracts).
 
 ```{r}
 github_repo <- "covid19-forecast-hub-europe/covid19-scenario-hub-europe"
@@ -62,11 +62,12 @@ metadata |>
   knitr::kable()
 ```
 
-## Models details
+## Model details
 
 ```{r, results='asis'}
 metadata |> 
   map("model_details") |> 
+  compact() |> 
   transpose() |> 
   imap(function(model_details, feature) {
     knitr::knit_child("_model_feature.Rmd", envir = environment())


### PR DESCRIPTION
In the "model details" section, the code errors when trying to `transpose()` a list with a NULL component.

I think this is why GH actions has been failing the website build [every time lately](https://github.com/covid19-forecast-hub-europe/covid19-scenario-hub-europe-website/actions).

The NULL element came from a duplicate version of the USC model metadata, which can be safely dropped.

Including `purrr::compact()` removes NULL elements which solves the issue.

(Separately, also fixed a dead link to model abstracts.)